### PR TITLE
Initial component layout, add Mobx and React Router

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,12 @@
     "@types/react": "16.9.2",
     "@types/react-dom": "16.9.0",
     "bootstrap": "4.3.1",
+    "mobx": "5.13.0",
+    "mobx-react": "6.1.3",
     "react": "^16.9.0",
     "react-dom": "^16.9.0",
+    "react-router": "5.0.1",
+    "react-router-dom": "5.0.1",
     "react-scripts": "3.1.1",
     "reactstrap": "8.0.1",
     "standard": "^14.1.0",
@@ -37,6 +41,9 @@
     ]
   },
   "devDependencies": {
+    "@types/react-redux": "7.1.2",
+    "@types/react-router": "5.0.3",
+    "@types/react-router-dom": "4.3.5",
     "@types/reactstrap": "8.0.4"
   }
 }

--- a/server.py
+++ b/server.py
@@ -1,7 +1,6 @@
 from hwilib import commands
 from flask import Flask, jsonify
 from flask_cors import CORS
-import json
 
 app = Flask(__name__)
 CORS(app)
@@ -13,12 +12,6 @@ def home():
 @app.route('/enumerate')
 def enumerate():
     return jsonify(commands.enumerate())
-
-@app.route('/psbt')
-def psbt():
-    with open('data/psbt_decoded.json'):
-        data = json.load(json_file)
-        return jsonify(data)
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/server.py
+++ b/server.py
@@ -1,6 +1,7 @@
 from hwilib import commands
 from flask import Flask, jsonify
 from flask_cors import CORS
+import json
 
 app = Flask(__name__)
 CORS(app)
@@ -12,6 +13,12 @@ def home():
 @app.route('/enumerate')
 def enumerate():
     return jsonify(commands.enumerate())
+
+@app.route('/psbt')
+def psbt():
+    with open('data/psbt_decoded.json'):
+        data = json.load(json_file)
+        return jsonify(data)
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,19 +1,24 @@
 import React from 'react';
-import { Navbar, NavbarBrand, Container, Col } from 'reactstrap';
-import Enumerate from './components/Enumerate'
+import { HashRouter } from 'react-router-dom';
+import { Switch, Route } from 'react-router';
+import Template from './components/Template';
+import Home from './components/Home';
+import Send from './components/Send';
+import Sign from './components/Sign';
+import History from './components/History';
 
 const App: React.FC = () => {
   return (
-    <div>
-      <Navbar color="light">
-        <NavbarBrand>Junction</NavbarBrand>
-      </Navbar>
-      <Container>
-        <Col>
-          <Enumerate/>
-        </Col>
-      </Container>
-    </div>
+    <HashRouter>
+      <Template>
+        <Switch>
+          <Route path="/" exact component={Home} />
+          <Route path="/send" component={Send} />
+          <Route path="/sign" component={Sign} />
+          <Route path="/history" component={History} />
+        </Switch>
+      </Template>
+    </HashRouter>
   );
 }
 

--- a/src/components/Enumerate.tsx
+++ b/src/components/Enumerate.tsx
@@ -1,41 +1,42 @@
 import React from 'react'
-import { enumerate } from '../api'
-import { Device } from '../types';
+import { observer, connect } from '../store';
+import { DeviceStore } from '../store/device';
+
+interface StoreProps {
+  device: DeviceStore;
+}
+
+type Props = StoreProps;
 
 interface State {
-  devices: Device[];
-  isLoaded: boolean;
+  isLoading: boolean;
   error: null | Error;
 }
 
-class Enumerate extends React.Component<{}, State> {
+@observer
+class Enumerate extends React.Component<Props, State> {
   state: State = {
     error: null,
-    isLoaded: false,
-    devices: []
+    isLoading: false,
   };
 
-  componentDidMount() {
-    enumerate().then(
-      (result) => {
-        this.setState({
-          isLoaded: true,
-          devices: result
-        });
-      },
-      (error) => {
-        this.setState({
-          isLoaded: true,
-          error
-        });
-      }
-    )
+  async componentDidMount() {
+    const { device } = this.props;
+    try {
+      this.setState({ isLoading: true });
+      await device.getDevices();
+    } catch(error) {
+      this.setState({ error });
+    }
+    this.setState({ isLoading: false });
   }
+
   render() {
-    const { error, isLoaded, devices } = this.state
+    const { devices } = this.props.device;
+    const { error, isLoading } = this.state
     if (error) {
       return <div>Error: {error.message}</div>;
-    } else if (!isLoaded) {
+    } else if (isLoading) {
       return <div>Loading...</div>;
     } else {
       return (
@@ -51,4 +52,6 @@ class Enumerate extends React.Component<{}, State> {
   }
 }
 
-export default Enumerate
+export default connect<StoreProps>(
+  ({ device }) => ({ device })
+)(Enumerate);

--- a/src/components/History.tsx
+++ b/src/components/History.tsx
@@ -1,0 +1,4 @@
+import React from 'react';
+
+// TODO: History page
+export default (() => <>I'm the History page</>) as React.SFC;

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import Enumerate from './Enumerate'
+
+export default class Home extends React.Component {
+  render() {
+    return (
+      <div>
+        <h1>Welcome home!</h1>
+        <p>Here are your devices:</p>    
+        <Enumerate />
+      </div>
+    )
+  }
+}

--- a/src/components/Send.tsx
+++ b/src/components/Send.tsx
@@ -1,0 +1,4 @@
+import React from 'react';
+
+// TODO: Send page
+export default (() => <>I'm the Send page</>) as React.SFC;

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1,0 +1,4 @@
+import React from 'react';
+
+// TODO: Settings page
+export default (() => <>I'm the Settings page</>) as React.SFC;

--- a/src/components/Sign.tsx
+++ b/src/components/Sign.tsx
@@ -1,0 +1,4 @@
+import React from 'react';
+
+// TODO: Sign page
+export default (() => <>I'm the Sign page</>) as React.SFC;

--- a/src/components/Template.tsx
+++ b/src/components/Template.tsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import { observer } from 'mobx-react';
+import { Link, NavLink as RRNavLink } from 'react-router-dom';
+import {
+  Navbar,
+  NavbarBrand,
+  NavbarToggler,
+  Container,
+  Collapse,
+  Nav,
+  NavItem,
+  NavLink,
+  DropdownToggle,
+  DropdownMenu,
+  Spinner,
+  DropdownItem,
+  UncontrolledDropdown,
+} from 'reactstrap';
+import { connect } from '../store';
+import { WalletStore } from '../store/wallet';
+
+interface StoreProps {
+  wallet: WalletStore;
+}
+
+interface OwnProps {
+  children: React.ReactNode;
+}
+
+type Props = StoreProps & OwnProps;
+
+interface State {
+  isLoadingWallets: boolean;
+  isOpen: boolean;
+}
+
+@observer
+class Template extends React.Component<Props, State> {
+  state: State = {
+    isLoadingWallets: false,
+    isOpen: false,
+  };
+
+  async componentDidMount() {
+    try {
+      this.setState({ isLoadingWallets: true });
+      await this.props.wallet.getWallets();
+    } catch(error) {
+      alert(error.message);
+    }
+    this.setState({ isLoadingWallets: false });
+  }
+
+  render() {
+    const { wallet } = this.props;
+    const { isOpen, isLoadingWallets } = this.state;
+    const navLinks = [{
+      to: '/send',
+      children: 'Send',
+    }, {
+      to: '/sign',
+      children: 'Sign',
+    }];
+
+    let dropdownLabel;
+    if (isLoadingWallets) {
+      dropdownLabel = <Spinner size="sm" />;
+    } else if (wallet.activeWallet) {
+      dropdownLabel = wallet.activeWallet.name;
+    } else {
+      dropdownLabel = 'Select a Wallet';
+    }
+
+    return (
+      <div>
+        <Navbar expand="md" color="light" light>
+          <Container>
+            <NavbarBrand tag={Link} to="/">
+              Junction
+            </NavbarBrand>
+            <NavbarToggler onClick={this.toggle} />
+            <Collapse isOpen={this.state.isOpen} navbar>
+              <Nav className="ml-auto" navbar>
+                {navLinks.map(l => (
+                  <NavItem key={l.to}>
+                    <NavLink
+                      tag={RRNavLink}
+                      activeClassName="active"
+                      exact
+                      {...l}
+                    />
+                  </NavItem>
+                ))}
+                <UncontrolledDropdown nav inNavbar>
+                  <DropdownToggle nav caret>
+                    {dropdownLabel}
+                  </DropdownToggle>
+                  <DropdownMenu>
+                    {wallet.wallets.map(w => (
+                      <DropdownItem
+                        key={w.name}
+                        active={w === wallet.activeWallet}
+                        onClick={() => wallet.changeWallet(w)}
+                      >
+                        {w.name} ({w.m} of {w.n})
+                      </DropdownItem>
+                    ))}
+                  </DropdownMenu>
+                </UncontrolledDropdown>
+              </Nav>
+            </Collapse>
+          </Container>
+        </Navbar>
+        <Container>
+          {this.props.children}
+        </Container>
+      </div>
+    );
+  }
+
+  private toggle = () => {
+    this.setState({ isOpen: !this.state.isOpen });
+  };
+};
+
+export default connect(({ wallet }) => ({ wallet }))(Template);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,11 +1,22 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
+import { Provider } from 'mobx-react';
 import App from './App'
 import * as serviceWorker from './serviceWorker'
+import { createStore } from './store';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import './index.css'
 
-ReactDOM.render(<App />, document.getElementById('root'))
+const store = createStore();
+
+ReactDOM.render(
+  (
+    <Provider {...store}>
+      <App />
+    </Provider>
+  ),
+  document.getElementById('root'),
+)
 
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.

--- a/src/store/device.ts
+++ b/src/store/device.ts
@@ -1,0 +1,20 @@
+import { observable, action, runInAction } from 'mobx';
+import { sleep } from '../util';
+import { Device, DeviceType } from '../types';
+
+export class DeviceStore {
+  @observable devices: Device[] = [];
+
+  // TODO: Actually get devices from python backend
+  @action
+  async getDevices() {
+    await sleep(500);
+    runInAction(() => {
+      this.devices = [{
+        name: 'Ledger',
+        type: DeviceType.ledger,
+        fingerprint: '123',
+      }];
+    });
+  }
+}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,0 +1,34 @@
+import { inject } from 'mobx-react';
+import { InferableComponentEnhancerWithProps } from 'react-redux';
+import { WalletStore } from './wallet';
+import { DeviceStore } from './device';
+
+export function createStore() {
+  const wallet = new WalletStore();
+  const device = new DeviceStore();
+  return { wallet, device };
+}
+
+// Here we're wrapping mobx's inject method to allow for strong typing
+// The goal here is to do two things:
+// 1) Not use inject's string arguments, which are virtually untypable
+// 2) Allow React components to specify which props come from mobx, and
+//    which props they need passed.
+// This uses some of @types/react-redux's handy typing, because that module
+// has way better typing.
+// Source: https://github.com/mobxjs/mobx-react/issues/256#issuecomment-496294124
+type MapStoresToProps<InjectedProps, OwnProps> = (
+  state: ReturnType<typeof createStore>,
+  ownProps: OwnProps,
+) => InjectedProps;
+
+export function connect<InjectedProps extends object, OwnProps extends object = {}>(
+  fn: MapStoresToProps<InjectedProps, OwnProps>
+) {
+  return inject(fn) as InferableComponentEnhancerWithProps<InjectedProps, OwnProps>;
+}
+
+// Convenience export for components, so they only need to import one file
+// for all their mobx component needs.
+export { action } from 'mobx';
+export { observer } from 'mobx-react';

--- a/src/store/wallet.ts
+++ b/src/store/wallet.ts
@@ -1,0 +1,33 @@
+import { observable, action, runInAction } from 'mobx';
+import { Wallet, DeviceType } from '../types';
+import { sleep } from '../util';
+
+export class WalletStore {
+  @observable wallets: Wallet[] = [];
+  @observable activeWallet: Wallet | null = null;
+
+  // TODO: Actually get wallets from python backend
+  @action
+  async getWallets() {
+    await sleep(300);
+    runInAction(() => {
+      this.wallets = [{
+        name: 'Cold storage',
+        m: 2,
+        n: 3,
+        signers: [{
+          name: 'Ledger',
+          type: DeviceType.ledger,
+          fingerprint: '123',
+          xpub: '456',
+        }],
+      }];
+      this.changeWallet(this.wallets[0]);
+    });
+  }
+
+  @action
+  changeWallet(wallet: Wallet) {
+    this.activeWallet = wallet;
+  }
+}

--- a/src/store/wallet.ts
+++ b/src/store/wallet.ts
@@ -21,6 +21,26 @@ export class WalletStore {
           fingerprint: '123',
           xpub: '456',
         }],
+      }, {
+        name: 'Family wallet',
+        m: 3,
+        n: 5,
+        signers: [{
+          name: 'Me',
+          type: DeviceType.ledger,
+          fingerprint: '123',
+          xpub: '456',
+        }, {
+          name: 'Mom',
+          type: DeviceType.ledger,
+          fingerprint: 'xyz',
+          xpub: '789',
+        }, {
+          name: 'Dad',
+          type: DeviceType.ledger,
+          fingerprint: 'abc',
+          xpub: '000',
+        }],
       }];
       this.changeWallet(this.wallets[0]);
     });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,1 +1,2 @@
 export * from './device';
+export * from './wallet';

--- a/src/types/wallet.ts
+++ b/src/types/wallet.ts
@@ -1,0 +1,16 @@
+import { DeviceType } from './device';
+
+export interface Signer {
+  name: string;
+  type: DeviceType;
+  fingerprint: string;
+  xpub: string;
+}
+
+// Aligns with MultisigWallet in junction.py
+export interface Wallet {
+  name: string;
+  m: number;
+  n: number;
+  signers: Signer[];
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,3 @@
+export function sleep(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react"
+    "jsx": "react",
+    "experimentalDecorators": true
   },
   "include": [
     "src"

--- a/yarn.lock
+++ b/yarn.lock
@@ -763,6 +763,13 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
+"@babel/runtime@^7.4.0":
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.6.0.tgz#4fc1d642a9fd0299754e8b5de62c631cf5568205"
+  integrity sha512-89eSBLJsxNxOERC0Op4vd+0Bqm6wRMqMbFtV3i0/fbaWw/mJ8Q3eBvgX0G4SyrOOLCtbu98HspF8o09MRT+KzQ==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
 "@babel/template@^7.1.0", "@babel/template@^7.4.0", "@babel/template@^7.4.4":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.4.4.tgz#f4b88d1225689a08f5bc3a17483545be9e4ed237"
@@ -1151,6 +1158,19 @@
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
   integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
 
+"@types/history@*":
+  version "4.7.3"
+  resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.3.tgz#856c99cdc1551d22c22b18b5402719affec9839a"
+  integrity sha512-cS5owqtwzLN5kY+l+KgKdRJ/Cee8tlmQoGQuIE9tWnSmS3JMKzmxo2HIAk2wODMifGwO20d62xZQLYz+RLfXmw==
+
+"@types/hoist-non-react-statics@^3.3.0":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
+  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz#42995b446db9a48a11a07ec083499a860e9138ff"
@@ -1208,6 +1228,33 @@
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.0.tgz#ba6ddb00bf5de700b0eb91daa452081ffccbfdea"
   integrity sha512-OL2lk7LYGjxn4b0efW3Pvf2KBVP0y1v3wip1Bp7nA79NkOpElH98q3WdCEdDj93b2b0zaeBG9DvriuKjIK5xDA==
   dependencies:
+    "@types/react" "*"
+
+"@types/react-redux@7.1.2":
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.1.2.tgz#02303b77d87e54f327c09507cf80ee3ca3063898"
+  integrity sha512-Iim6UCtD0mZX9U3jBuT6ZObBZ8UlakoOgefiRgi5wakfbNnXd3TUwwUMgi3Ijc0fxsPLZ5ULoz0oDy15YIaLmQ==
+  dependencies:
+    "@types/hoist-non-react-statics" "^3.3.0"
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+    redux "^4.0.0"
+
+"@types/react-router-dom@4.3.5":
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/@types/react-router-dom/-/react-router-dom-4.3.5.tgz#72f229967690c890d00f96e6b85e9ee5780db31f"
+  integrity sha512-eFajSUASYbPHg2BDM1G8Btx+YqGgvROPIg6sBhl3O4kbDdYXdFdfrgQFf/pcBuQVObjfT9AL/dd15jilR5DIEA==
+  dependencies:
+    "@types/history" "*"
+    "@types/react" "*"
+    "@types/react-router" "*"
+
+"@types/react-router@*", "@types/react-router@5.0.3":
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/@types/react-router/-/react-router-5.0.3.tgz#855a1606e62de3f4d69ea34fb3c0e50e98e964d5"
+  integrity sha512-j2Gge5cvxca+5lK9wxovmGPgpVJMwjyu5lTA/Cd6fLGoPq7FXcUE1jFkEdxeyqGGz8VfHYSHCn5Lcn24BzaNKA==
+  dependencies:
+    "@types/history" "*"
     "@types/react" "*"
 
 "@types/react@*", "@types/react@16.9.2":
@@ -4605,6 +4652,18 @@ hex-color-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
 
+history@^4.9.0:
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/history/-/history-4.9.0.tgz#84587c2068039ead8af769e9d6a6860a14fa1bca"
+  integrity sha512-H2DkjCjXf0Op9OAr6nJ56fcRkTSNrUiv41vNJ6IswJjif6wlpZK0BTfFbi7qK9dXLSYZxkq5lBsj3vUjlYBYZA==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    loose-envify "^1.2.0"
+    resolve-pathname "^2.2.0"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
+    value-equal "^0.4.0"
+
 hmac-drbg@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
@@ -4613,6 +4672,13 @@ hmac-drbg@^1.0.0:
     hash.js "^1.0.3"
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
+
+hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz#b09178f0122184fb95acf525daaecb4d8f45958b"
+  integrity sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==
+  dependencies:
+    react-is "^16.7.0"
 
 hosted-git-info@^2.1.4:
   version "2.8.4"
@@ -5248,6 +5314,11 @@ is-wsl@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
   integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
+
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
 
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
@@ -6095,7 +6166,7 @@ loglevel@^1.4.1:
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.3.tgz#77f2eb64be55a404c9fd04ad16d57c1d6d6b1280"
   integrity sha512-LoEDv5pgpvWgPF4kNYuIp0qqSJVWak/dML0RY74xlzMZiT9w77teNAwKYKWBTYjlokMirg+o3jBwp+vlLrcfAA==
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -6289,6 +6360,15 @@ mimic-fn@^2.0.0, mimic-fn@^2.1.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
+mini-create-react-context@^0.3.0:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/mini-create-react-context/-/mini-create-react-context-0.3.2.tgz#79fc598f283dd623da8e088b05db8cddab250189"
+  integrity sha512-2v+OeetEyliMt5VHMXsBhABoJ0/M4RCe7fatd/fBy6SMiKazUSEt3gxxypfnk2SHMkdBYvorHRoQxuGoiwbzAw==
+  dependencies:
+    "@babel/runtime" "^7.4.0"
+    gud "^1.0.0"
+    tiny-warning "^1.0.2"
+
 mini-css-extract-plugin@0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-0.5.0.tgz#ac0059b02b9692515a637115b0cc9fed3a35c7b0"
@@ -6383,6 +6463,23 @@ mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.1:
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
   dependencies:
     minimist "0.0.8"
+
+mobx-react-lite@1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/mobx-react-lite/-/mobx-react-lite-1.4.0.tgz#193beb5fdddf17ae61542f65ff951d84db402351"
+  integrity sha512-5xCuus+QITQpzKOjAOIQ/YxNhOl/En+PlNJF+5QU4Qxn9gnNMJBbweAdEW3HnuVQbfqDYEUnkGs5hmkIIStehg==
+
+mobx-react@6.1.3:
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/mobx-react/-/mobx-react-6.1.3.tgz#ad07880ea60cdcdb2a7e2a0d54e01379710cf00a"
+  integrity sha512-eT/jO9dYIoB1AlZwI2VC3iX0gPOeOIqZsiwg7tDJV1B7Z69h+TZZL3dgOE0UeS2zoHhGeKbP+K+OLeLMnnkGnA==
+  dependencies:
+    mobx-react-lite "1.4.0"
+
+mobx@5.13.0:
+  version "5.13.0"
+  resolved "https://registry.yarnpkg.com/mobx/-/mobx-5.13.0.tgz#0fd68f10aa5ff2d146a4ed9e145b53337cfbca59"
+  integrity sha512-eSAntMSMNj0PFL705rgv+aB/z1RjNqDnFEpBe18yQVreXTWiVgIrmBUXzjnJfuba+eo4eAk6zi+/gXQkSUea8A==
 
 move-concurrently@^1.0.1:
   version "1.0.1"
@@ -7073,6 +7170,13 @@ path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
   integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
+
+path-to-regexp@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
+  integrity sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=
+  dependencies:
+    isarray "0.0.1"
 
 path-type@^2.0.0:
   version "2.0.0"
@@ -8156,7 +8260,7 @@ react-error-overlay@^6.0.1:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.1.tgz#b8d3cf9bb991c02883225c48044cb3ee20413e0f"
   integrity sha512-V9yoTr6MeZXPPd4nV/05eCBvGH9cGzc52FN8fs0O0TVQ3HYYf1n7EgZVtHbldRq5xU9zEzoXIITjYNIfxDDdUw==
 
-react-is@^16.8.1, react-is@^16.8.4:
+react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4:
   version "16.9.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.9.0.tgz#21ca9561399aad0ff1a7701c01683e8ca981edcb"
   integrity sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==
@@ -8177,6 +8281,35 @@ react-popper@^1.3.3:
     prop-types "^15.6.1"
     typed-styles "^0.0.7"
     warning "^4.0.2"
+
+react-router-dom@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.0.1.tgz#ee66f4a5d18b6089c361958e443489d6bab714be"
+  integrity sha512-zaVHSy7NN0G91/Bz9GD4owex5+eop+KvgbxXsP/O+iW1/Ln+BrJ8QiIR5a6xNPtrdTvLkxqlDClx13QO1uB8CA==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    history "^4.9.0"
+    loose-envify "^1.3.1"
+    prop-types "^15.6.2"
+    react-router "5.0.1"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
+
+react-router@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-5.0.1.tgz#04ee77df1d1ab6cb8939f9f01ad5702dbadb8b0f"
+  integrity sha512-EM7suCPNKb1NxcTZ2LEOWFtQBQRQXecLxVpdsP4DW4PbbqYWeRiLyV/Tt1SdCrvT2jcyXAXmVTmzvSzrPR63Bg==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    history "^4.9.0"
+    hoist-non-react-statics "^3.1.0"
+    loose-envify "^1.3.1"
+    mini-create-react-context "^0.3.0"
+    path-to-regexp "^1.7.0"
+    prop-types "^15.6.2"
+    react-is "^16.6.0"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
 
 react-scripts@3.1.1:
   version "3.1.1"
@@ -8351,6 +8484,14 @@ recursive-readdir@2.2.2:
   integrity sha512-nRCcW9Sj7NuZwa2XvH9co8NPeXUBhZP7CRKJtU+cS6PW9FpCIFoI5ib0NT1ZrbNuPoRy0ylyCaUL8Gih4LSyFg==
   dependencies:
     minimatch "3.0.4"
+
+redux@^4.0.0:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.4.tgz#4ee1aeb164b63d6a1bcc57ae4aa0b6e6fa7a3796"
+  integrity sha512-vKv4WdiJxOWKxK0yRoaK3Y4pxxB0ilzVx6dszU2W8wLxlb2yikRph4iV/ymtdJ6ZxpBLFbyrxklnT5yBbQSl3Q==
+  dependencies:
+    loose-envify "^1.4.0"
+    symbol-observable "^1.2.0"
 
 regenerate-unicode-properties@^8.1.0:
   version "8.1.0"
@@ -8537,6 +8678,11 @@ resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
   integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
+
+resolve-pathname@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-2.2.0.tgz#7e9ae21ed815fd63ab189adeee64dc831eefa879"
+  integrity sha512-bAFz9ld18RzJfddgrO2e/0S2O81710++chRMUxHjXOYKF6jTAMrUNZrEZ1PvV0zlhfjidm08iRPdTLPno1FuRg==
 
 resolve-url-loader@3.1.0:
   version "3.1.0"
@@ -9370,6 +9516,11 @@ svgo@^1.0.0, svgo@^1.2.2:
     unquote "~1.1.1"
     util.promisify "~1.0.0"
 
+symbol-observable@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
+  integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
+
 symbol-tree@^3.2.2:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
@@ -9476,6 +9627,16 @@ timsort@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
   integrity sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=
+
+tiny-invariant@^1.0.2:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.0.6.tgz#b3f9b38835e36a41c843a3b0907a5a7b3755de73"
+  integrity sha512-FOyLWWVjG+aC0UqG76V53yAWdXfH8bO6FNmyZOuUrzDzK8DI3/JRY25UD7+g49JWM1LXwymsKERB+DzI0dTEQA==
+
+tiny-warning@^1.0.0, tiny-warning@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
+  integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
 
 tmp@^0.0.33:
   version "0.0.33"
@@ -9838,6 +9999,11 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
+
+value-equal@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-0.4.0.tgz#c5bdd2f54ee093c04839d71ce2e4758a6890abc7"
+  integrity sha512-x+cYdNnaA3CxvMaTX0INdTCN8m8aF2uY9BvEqmxuYp8bL09cs/kWVQPVGcA35fMktdOsP69IgU7wFj/61dJHEw==
 
 vary@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
### What This Does

This does some initial frontend setup using reactstrap, mobx, and react router. This adds a navigation and some pages, as well as an initial layout of what the store would look like using Mobx.

I used Mobx in an attempt to reduce the boilerplate, but I think it added a nonzero amount of complexity. For starters, observables are a little tricky to use, and come with a bunch of caveats. I also had to hack around and create a custom connect function to get the typing to be strong (The maintainers of mobx suggest either making all types optional, or to start using React hooks. Neither of those options seemed appealing.)

At this point I could go either way. We could either swap it out with Redux, remove all extra state management, try yet another state management, or just dig in with Mobx.

### Steps to Test

* Browse around, make sure the hash router updates
* Refresh the page, make sure it starts on the same page
* Select a wallet, make sure it changes
* Check that all components have some kind of loading state while the actions fake-load (all data is stubbed out.)

## Screenshots

<img width="1218" alt="Screen Shot 2019-09-08 at 7 16 17 PM" src="https://user-images.githubusercontent.com/649992/64496652-283f0e00-d26d-11e9-862a-5075f3c5d000.png">
