### PR TITLE
tidy up resources in a way that unittest do not raise ResourceWarning

### DIFF
--- a/test/test_wallet.py
+++ b/test/test_wallet.py
@@ -66,7 +66,12 @@ class WalletTests(unittest.TestCase):
         cls.maxDiff = 10000  # FIXME: descriptor test maxed out this parameter
         test_dir = os.path.dirname(os.path.realpath(__file__))
         bitcoind_path = os.path.join(test_dir, 'bitcoin/src/bitcoind')
-        cls.rpc, cls.rpc_username, cls.rpc_password = start_bitcoind(bitcoind_path)
+        cls.rpc, cls.rpc_username, cls.rpc_password, cls.bitcoind_proc = start_bitcoind(bitcoind_path)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.bitcoind_proc.kill()
+        cls.rpc._AuthServiceProxy__conn.close()
 
     def setUp(self):
         # a hack to use a new temporary datadir for every unittest ...

--- a/test/utils.py
+++ b/test/utils.py
@@ -13,7 +13,8 @@ def start_bitcoind(bitcoind_path):
     datadir = tempfile.mkdtemp()
     bitcoind_proc = subprocess.Popen([bitcoind_path, '-regtest', '-datadir=' + datadir, '-noprinttoconsole'])
     def cleanup_bitcoind():
-        bitcoind_proc.kill()
+        bitcoind_proc.kill() # might not be needed but doesn't hurt either
+        bitcoind_proc.wait()
         shutil.rmtree(datadir)
     atexit.register(cleanup_bitcoind)
     # Wait for cookie file to be created
@@ -36,4 +37,14 @@ def start_bitcoind(bitcoind_path):
 
     # Make sure there are blocks and coins available
     rpc.generatetoaddress(101, rpc.getnewaddress())
-    return (rpc, rpc_username, rpc_password)
+    return (rpc, rpc_username, rpc_password, bitcoind_proc)
+
+def write_json_file(data, filename):
+    path = os.path.join(junction_dir, filename)
+    with open(path, 'w') as f:
+        return json.dump(data, f, indent=4)
+
+def read_json_file(filename):
+    path = os.path.join(junction_dir, filename)
+    with open(path, 'r') as f:
+        return json.load(f)


### PR DESCRIPTION
Removes these ResourceWarnings
```
----------------------------------------------------------------------
Ran 11 tests in 4.614s

OK (skipped=1)
Exception ignored in: <bound method Popen.__del__ of <subprocess.Popen object at 0x7f4a7e0de400>>
Traceback (most recent call last):
  File "/home/kim/.pyenv/versions/3.6.6/lib/python3.6/subprocess.py", line 766, in __del__
    ResourceWarning, source=self)
ResourceWarning: subprocess 15558 is still running
Exception ignored in: <socket.socket fd=3, family=AddressFamily.AF_INET, type=2049, proto=6, laddr=('127.0.0.1', 51662), raddr=('127.0.0.1', 18443)>
ResourceWarning: unclosed <socket.socket fd=3, family=AddressFamily.AF_INET, type=2049, proto=6, laddr=('127.0.0.1', 51662), raddr=('127.0.0.1', 18443)>
```
There are lots of other ResourceWarnings and i tried to fix them via using a ContextManager as described in https://stackoverflow.com/posts/54612520/revisions
You can have a look in my testing_context_manager branch.
https://github.com/k9ert/junction/commit/5684c0724b4a92c7802e23564122b5d7e52eb06d
For some reason the wallet_rpc.importmulti-call resisted that solution heavily, that's why 4 tests broke and i didn't included that in this PR. 
Are you happy with a context-manager in general for your RPC-class?
Would you be happy to use pytest?
Why don't you merge the testing-branch to master? I'd worry about diverging stuff too much with too man y branches.